### PR TITLE
Fix typo in Entities.encodeRaw documentation

### DIFF
--- a/js/tinymce/classes/html/Entities.js
+++ b/js/tinymce/classes/html/Entities.js
@@ -119,7 +119,7 @@ define("tinymce/html/Entities", [
 
 	var Entities = {
 		/**
-		 * Encodes the specified string using raw entities. This means only the required XML base entities will be endoded.
+		 * Encodes the specified string using raw entities. This means only the required XML base entities will be encoded.
 		 *
 		 * @method encodeRaw
 		 * @param {String} text Text to encode.


### PR DESCRIPTION
``` diff
- endoded
+ encoded
```
